### PR TITLE
Add explanation of what is sent to HMRC

### DIFF
--- a/app/views/information-provided.html
+++ b/app/views/information-provided.html
@@ -63,6 +63,20 @@ text: "beta" }, html: 'This is a new service – your
     >
       Skip Verify
     </a>
+
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          What information is sent to HMRC?
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        We send HMRC your full name, date of birth and gender details to ensure
+        your tax contributions are met. You will still receive your full payment
+        as we cover your tax obligations in addition to the payment we make to
+        you.
+      </div>
+    </details>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
The how we will use the information you provide section needs the
details of what information we will send to HMRC. This is similar to
what we show in the student loan journey but we do not include the loan
repayment amount.