### PR TITLE
Make the changes to questions and static text

### DIFF
--- a/app/views/awarded.html
+++ b/app/views/awarded.html
@@ -1,32 +1,23 @@
+{% extends "layout.html" %} {% block pageTitle %} DfE Maths and Physics Service
+Prototype {% endblock %} {% block beforeContent %} {{ govukPhaseBanner({ tag: {
+text: "beta" }, html: 'This is a new service – your
+<a class="govuk-link" href="#">feedback</a> will help us to improve it.' }) }}
 
-{% extends "layout.html" %}
-
-{% block pageTitle %}
-  DfE Maths and Physics Service Prototype
-{% endblock %}
-
-{% block beforeContent %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "beta"
-    },
-    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
-  }) }}
-
-  {{ govukBackLink({
+{{
+  govukBackLink({
     text: "Back",
     href: "/qualified"
-  }) }}
-{% endblock %}
+  })
+}}
+{% endblock %} {% block content %}
 
-{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <form method="POST" action="awarded">
+      {% from "radios/macro.njk" import govukRadios %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <form method="POST" action="awarded">
-        {% from "radios/macro.njk" import govukRadios %}
-
-        {{ govukRadios({
+      {{
+        govukRadios({
           classes: "govuk-radios",
           idPrefix: "awarded",
           name: "awarded",
@@ -39,27 +30,30 @@
           },
           items: [
             {
-              value: "On or after 1 September 2014",
-              text: "On or after 1 September 2014",
+              value: "Before 1 September 2013",
+              text: "Before 1 September 2013"
+            },
+            {
+              value: "On or after 1 September 2013",
+              text: "On or after 1 September 2013",
               attributes: {
                 required: "true"
               }
-            },
-            {
-              value: "Before 1 September 2014",
-              text: "Before 1 September 2014"
             }
           ]
-        }) }}
+        })
+      }}
 
-        {% from "button/macro.njk" import govukButton %}
+      {% from "button/macro.njk" import govukButton %}
 
-        {{ govukButton({
+      {{
+        govukButton({
           text: "Continue",
           preventDoubleClick: true
-        }) }}
-      </form>
-    </div>
+        })
+      }}
+    </form>
   </div>
+</div>
 
 {% endblock %}

--- a/app/views/check-answers.html
+++ b/app/views/check-answers.html
@@ -331,24 +331,40 @@ govukPhaseBanner %} {% block beforeContent %} {{ govukPhaseBanner({ tag: { text:
       Payment details
     </h2>
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      {% if data['name-on-the-account'] %}
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Bank sort code:
+          Name on the account
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body">
+            {{ data["name-on-the-account"] }}
+          </p>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="/payment-method">
+            Change<span class="govuk-visually-hidden"> your answer</span>
+          </a>
+        </dd>
+      </div>
+      {% endif %} {% if data['sort-code'] %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Sort code
         </dt>
         <dd class="govuk-summary-list__value">
           <p class="govuk-body">{{ data["sort-code"] }}</p>
         </dd>
         <dd class="govuk-summary-list__actions">
           <a class="govuk-link" href="/payment-method">
-            Change<span class="govuk-visually-hidden">
-              your bank sort code</span
-            >
+            Change<span class="govuk-visually-hidden"> your answer</span>
           </a>
         </dd>
       </div>
+      {% endif %} {% if data['account-number'] %}
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Bank account number:
+          Account Number
         </dt>
         <dd class="govuk-summary-list__value">
           <p class="govuk-body">
@@ -357,12 +373,25 @@ govukPhaseBanner %} {% block beforeContent %} {{ govukPhaseBanner({ tag: { text:
         </dd>
         <dd class="govuk-summary-list__actions">
           <a class="govuk-link" href="/payment-method">
-            Change<span class="govuk-visually-hidden">
-              your bank account number</span
-            >
+            Change<span class="govuk-visually-hidden"> your answer</span>
           </a>
         </dd>
       </div>
+      {% endif %} {% if data['roll-number'] %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Building society roll number
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body">Sort code:<br />{{ data["roll-number"] }}</p>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="/payment-method">
+            Change<span class="govuk-visually-hidden"> your answer</span>
+          </a>
+        </dd>
+      </div>
+      {% endif %}
     </dl>
 
     <h2 class="govuk-heading-m">Confirm your claim</h2>

--- a/app/views/eligible-confirmed.html
+++ b/app/views/eligible-confirmed.html
@@ -15,7 +15,7 @@ text: "beta" }, html: 'This is a new service – your
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-label-wrapper">
       <label class="govuk-label govuk-label--xl">
-        You're eligible to receive &pound;2,000
+        You're eligible to claim &pound;2,000
       </label>
     </h1>
   </div>
@@ -24,8 +24,8 @@ text: "beta" }, html: 'This is a new service – your
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">
-      Based on your answers you can claim a &pound;2,000 payment for teaching
-      maths or physics.
+      Based on your answers you can claim &pound;2,000 for teaching maths or
+      physics.
     </p>
 
     <a href="/information-provided" role="button" class="govuk-button">

--- a/app/views/number-of-courses.html
+++ b/app/views/number-of-courses.html
@@ -23,7 +23,8 @@ text: "beta" }, html: 'This is a new service – your
           name: "numberOfCourses",
           fieldset: {
             legend: {
-              text: "How many degree courses have you studied?",
+              text:
+                "How many higher education courses did you take a student loan out for?",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--xl"
             }

--- a/app/views/payment-method.html
+++ b/app/views/payment-method.html
@@ -14,26 +14,39 @@ text: "beta" }, html: 'This is a new service – your
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <form method="POST" action="payment-method">
-      {% from "input/macro.njk" import govukInput %} {% from
-      "fieldset/macro.njk" import govukFieldset %} {% call govukFieldset({
-      legend: { text: "Enter bank account details", isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl" } }) %}
+      {% from "button/macro.njk" import govukButton %} {% from "input/macro.njk"
+      import govukInput %}
 
-      <span class="govuk-hint">
-        The account you want us to send your payment to.
-      </span>
+      <h1 class="govuk-heading-xl">Bank or building society account details</h1>
+
+      {{
+        govukInput({
+          label: {
+            text: "Name on the account"
+          },
+          hint: { text: "The account you want us to send your payment to." },
+          id: "name-on-the-account",
+          name: "name-on-the-account",
+          attributes: {
+            spellcheck: "false"
+          }
+        })
+      }}
 
       {{
         govukInput({
           label: {
             text: "Sort code"
           },
+          classes: "govuk-input--width-5",
           hint: {
-            text: "For example: 44 00 26"
+            text: "Must be 6 digits long"
           },
           id: "sort-code",
           name: "sort-code",
-          classes: "govuk-!-width-one-quarter"
+          attributes: {
+            spellcheck: "false"
+          }
         })
       }}
 
@@ -42,21 +55,38 @@ text: "beta" }, html: 'This is a new service – your
           label: {
             text: "Account number"
           },
+          classes: "govuk-input--width-10",
           hint: {
-            text: "For example: 70 87 24 90"
+            text: "Must be between 6 and 8 digits long"
           },
-          classes: "govuk-input--width-20",
           id: "account-number",
-          name: "account-number"
+          name: "account-number",
+          attributes: {
+            spellcheck: "false"
+          }
         })
       }}
 
-      {% endcall %} {% from "button/macro.njk" import govukButton %}
+      {{
+        govukInput({
+          label: {
+            text: "Building society roll number (if you have one)"
+          },
+          classes: "govuk-input--width-10",
+          hint: {
+            text: "You can find it on your card, statement or passbook"
+          },
+          id: "roll-number",
+          name: "roll-number",
+          attributes: {
+            spellcheck: "false"
+          }
+        })
+      }}
 
       {{
         govukButton({
-          text: "Continue",
-          preventDoubleClick: true
+          text: "Continue"
         })
       }}
     </form>

--- a/app/views/repaying-loan.html
+++ b/app/views/repaying-loan.html
@@ -23,7 +23,7 @@ text: "beta" }, html: 'This is a new service – your
           name: "repayingLoan",
           fieldset: {
             legend: {
-              text: "Are you still paying off your student loan?",
+              text: "Are you still paying off a UK student loan?",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--xl"
             }


### PR DESCRIPTION
# 1 Remove references to a £2,000 payment, it should be a claim
![image](https://user-images.githubusercontent.com/13239597/66322407-f8d9fa80-e919-11e9-9003-ac49f2f182ed.png)

# 2 Repaying student loan question now asks if they are paying off a **UK student loan**
![image](https://user-images.githubusercontent.com/13239597/66322364-ed86cf00-e919-11e9-8884-4a1f2cef06ee.png)

# 3 Number of courses question asks how many higher education courses they took a student loan out for
![image](https://user-images.githubusercontent.com/13239597/66322325-db0c9580-e919-11e9-8bec-c5b94932132c.png)

# 4 Payment method screen is updated to include building society and name on account fields
![image](https://user-images.githubusercontent.com/13239597/66322297-cc25e300-e919-11e9-88dd-ca628ca692e0.png)
 