### PR TITLE
Add in Accessibility Statement

### DIFF
--- a/app/views/accessibility-statement.html
+++ b/app/views/accessibility-statement.html
@@ -1,0 +1,154 @@
+{% extends "layout.html" %} {% block pageTitle %} DfE Maths and Physics Service
+Prototype {% endblock %} {% block beforeContent %} {{ govukPhaseBanner({ tag: {
+text: "beta" }, html: 'This is a new service – your
+<a class="govuk-link" href="#">feedback</a> will help us to improve it.' }) }}
+
+{{
+  govukBackLink({
+    text: "Back",
+    href: "/start"
+  })
+}}
+{% endblock %} {% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Accessibility statement for Claim a payment for teaching maths or physics
+    </h1>
+
+    <p class="govuk-body">
+      This website is run by the Department for Education. We want as many
+      people as possible to be able to use this website. For example, that means
+      you should be able to:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>zoom in up to 300&#37; without the text spilling off the screen</li>
+      <li>
+        navigate most of the website using just a keyboard (please note if you
+        are using JAWS you may need to tab into text boxes to enter your answer)
+      </li>
+      <li>navigate most of the website using speech recognition software</li>
+      <li>
+        listen to most of the website using a screen reader (including the most
+        recent versions of JAWS, NVDA and VoiceOver)
+      </li>
+      <li>
+        use speech to text to enter information (please note if you are using
+        Dragon Speech Recognition you may need to use the DragonPad tool to
+        enter information)
+      </li>
+    </ul>
+
+    <p class="govuk-body">
+      We’ve also made the website text as simple as possible to understand.
+    </p>
+
+    <p class="govuk-body">
+      <a href="https://mcmw.abilitynet.org.uk/" class="govuk-link"
+        >AbilityNet</a
+      >
+      has advice on making your device easier to use if you have a disability.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      How accessible this website is
+    </h2>
+
+    <p class="govuk-body">
+      We know some parts of this website aren’t fully accessible:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>you can’t modify the line height or spacing of text</li>
+      <li>you can’t change colours, contrast levels and fonts</li>
+    </ul>
+
+    <h2 class="govuk-heading-l">
+      What to do if you can’t access parts of this website
+    </h2>
+
+    <p class="govuk-body">
+      If you need information on this website in a different format or cannot
+      use the service, contact us at
+      <a
+        class="govuk-footer__link"
+        href="mailto:mathsphysicsteacherpayment@digital.education.gov.uk"
+        >mathsphysicsteacherpayment@digital.education.gov.uk</a
+      >.
+    </p>
+
+    <p class="govuk-body">
+      We’ll consider your request and get back to you within 5 working days.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      Reporting accessibility problems with this website
+    </h2>
+
+    <p class="govuk-body">
+      We’re always looking to improve the accessibility of this website. If you
+      find any problems that aren’t listed on this page or think we’re not
+      meeting accessibility requirements, contact us at
+      <a
+        class="govuk-footer__link"
+        href="mailto:mathsphysicsteacherpayment@digital.education.gov.uk"
+        >mathsphysicsteacherpayment@digital.education.gov.uk</a
+      >.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      Enforcement procedure
+    </h2>
+
+    <p class="govuk-body">
+      The Equality and Human Rights Commission (EHRC) is responsible for
+      enforcing the Public Sector Bodies (Websites and Mobile Applications) (No.
+      2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If
+      you’re not happy with how we respond to your complaint,
+      <a href="https://www.equalityadvisoryservice.com/" class="govuk-link">
+        contact the Equality Advisory and Support Service (EASS)</a
+      >.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      Technical information about this website’s accessibility
+    </h2>
+
+    <p class="govuk-body">
+      The Department for Education is committed to making its website
+      accessible, in accordance with the Public Sector Bodies (Websites and
+      Mobile Applications) (No. 2) Accessibility Regulations 2018.
+    </p>
+
+    <p class="govuk-body">
+      We believe this website is compliant with the Web Content Accessibility
+      Guidelines version 2.1 AA standard.
+    </p>
+
+    <h2 class="govuk-heading-l">How we tested this website</h2>
+
+    <p class="govuk-body">
+      This website was last tested on 2 September 2019. The test was carried out
+      internally.
+    </p>
+
+    <p class="govuk-body">
+      We tested:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        the ‘Claim a payment for teaching maths or physics‘
+      </li>
+    </ul>
+
+    <p class="govuk-body">
+      This statement was prepared on 31 July 2019. It was last updated on 8
+      October 2019.
+    </p>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -1,83 +1,58 @@
-{% extends "template.njk" %}
-
-{% from "accordion/macro.njk"        import govukAccordion %}
-{% from "back-link/macro.njk"        import govukBackLink %}
-{% from "breadcrumbs/macro.njk"      import govukBreadcrumbs %}
-{% from "button/macro.njk"           import govukButton %}
-{% from "character-count/macro.njk"  import govukCharacterCount %}
-{% from "checkboxes/macro.njk"       import govukCheckboxes %}
-{% from "date-input/macro.njk"       import govukDateInput %}
-{% from "details/macro.njk"          import govukDetails %}
-{% from "error-message/macro.njk"    import govukErrorMessage %}
-{% from "error-summary/macro.njk"    import govukErrorSummary %}
-{% from "fieldset/macro.njk"         import govukFieldset %}
-{% from "file-upload/macro.njk"      import govukFileUpload %}
-{% from "input/macro.njk"            import govukInput %}
-{% from "inset-text/macro.njk"       import govukInsetText %}
-{% from "panel/macro.njk"            import govukPanel %}
-{% from "phase-banner/macro.njk"     import govukPhaseBanner %}
-{% from "radios/macro.njk"           import govukRadios %}
-{% from "select/macro.njk"           import govukSelect %}
-{% from "skip-link/macro.njk"        import govukSkipLink %}
-{% from "summary-list/macro.njk"     import govukSummaryList %}
-{% from "table/macro.njk"            import govukTable %}
-{% from "tabs/macro.njk"             import govukTabs %}
-{% from "tag/macro.njk"              import govukTag %}
-{% from "textarea/macro.njk"         import govukTextarea %}
-{% from "warning-text/macro.njk"     import govukWarningText %}
-
-{% block head %}
-  {% include "includes/head.html" %}
-{% endblock %}
-
-{% block pageTitle %}
-  GOV.UK Prototype Kit
-{% endblock %}
-
-{% block header %}
-  {% include "includes/cookie-banner.html" %}
-  {# Set serviceName in config.js. #}
-  {{ govukHeader({
+{% extends "template.njk" %} {% from "accordion/macro.njk" import govukAccordion
+%} {% from "back-link/macro.njk" import govukBackLink %} {% from
+"breadcrumbs/macro.njk" import govukBreadcrumbs %} {% from "button/macro.njk"
+import govukButton %} {% from "character-count/macro.njk" import
+govukCharacterCount %} {% from "checkboxes/macro.njk" import govukCheckboxes %}
+{% from "date-input/macro.njk" import govukDateInput %} {% from
+"details/macro.njk" import govukDetails %} {% from "error-message/macro.njk"
+import govukErrorMessage %} {% from "error-summary/macro.njk" import
+govukErrorSummary %} {% from "fieldset/macro.njk" import govukFieldset %} {%
+from "file-upload/macro.njk" import govukFileUpload %} {% from "input/macro.njk"
+import govukInput %} {% from "inset-text/macro.njk" import govukInsetText %} {%
+from "panel/macro.njk" import govukPanel %} {% from "phase-banner/macro.njk"
+import govukPhaseBanner %} {% from "radios/macro.njk" import govukRadios %} {%
+from "select/macro.njk" import govukSelect %} {% from "skip-link/macro.njk"
+import govukSkipLink %} {% from "summary-list/macro.njk" import govukSummaryList
+%} {% from "table/macro.njk" import govukTable %} {% from "tabs/macro.njk"
+import govukTabs %} {% from "tag/macro.njk" import govukTag %} {% from
+"textarea/macro.njk" import govukTextarea %} {% from "warning-text/macro.njk"
+import govukWarningText %} {% block head %} {% include "includes/head.html" %}
+{% endblock %} {% block pageTitle %} GOV.UK Prototype Kit {% endblock %} {%
+block header %} {% include "includes/cookie-banner.html" %} {# Set serviceName
+in config.js. #}
+{{
+  govukHeader({
     homepageUrl: "/",
     serviceName: serviceName,
     serviceUrl: "/",
     containerClasses: "govuk-width-container"
-  }) }}
-{% endblock %}
-
-{% block beforeContent %}
-  {% from "phase-banner/macro.njk" import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "beta"
-    },
-    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
-  }) }}
-{% endblock %}
-
-{% if useAutoStoreData %}
-  {% block footer %}
-    {{ govukFooter({
-      meta: {
-        items: [
-          {
-            href: "https://govuk-prototype-kit.herokuapp.com/",
-            text: "GOV.UK Prototype Kit " + releaseVersion
-          },
-          {
-            href: "/prototype-admin/clear-data",
-            text: "Clear data"
-          }
-        ]
-      }
-    }) }}
-  {% endblock %}
-{% endif %}
-
-{% block bodyEnd %}
-  {% block scripts %}
-    {% include "includes/scripts.html" %}
-    {% block pageScripts %}{% endblock %}
-  {% endblock %}
-  <!-- GOV.UK Prototype Kit {{releaseVersion}} -->
+  })
+}}
+{% endblock %} {% block beforeContent %} {% from "phase-banner/macro.njk" import
+govukPhaseBanner %} {{ govukPhaseBanner({ tag: { text: "beta" }, html: 'This is
+a new service – your <a class="govuk-link" href="#">feedback</a> will help us to
+improve it.' }) }} {% endblock %} {% if useAutoStoreData %} {% block footer %}
+{{
+  govukFooter({
+    meta: {
+      items: [
+        {
+          href: "/accessibility-statement.html",
+          text: "Accessibility Statement"
+        },
+        {
+          href: "https://govuk-prototype-kit.herokuapp.com/",
+          text: "GOV.UK Prototype Kit " + releaseVersion
+        },
+        {
+          href: "/prototype-admin/clear-data",
+          text: "Clear data"
+        }
+      ]
+    }
+  })
+}}
+{% endblock %} {% endif %} {% block bodyEnd %} {% block scripts %} {% include
+"includes/scripts.html" %} {% block pageScripts %}{% endblock %} {% endblock %}
+<!-- GOV.UK Prototype Kit {{releaseVersion}} -->
 {% endblock %}


### PR DESCRIPTION
This is pretty much a copy of the teacher claim student loan
reimbursements page but with a couple of tweaks.

- Email address changed to Maths and Physics Service support Email
- Service name changed throughout
- Last test date updated
- Last test conducted internally