### PR TITLE
Create privacy notice for Maths and Physics

### DIFF
--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -74,16 +74,20 @@ improve it.' }) }}
           text: "Contact us"
         },
         {
+          href: "/privacy-notice.html",
+          text: "Privacy notice"
+        },
+        {
           href: "/accessibility-statement.html",
           text: "Accessibility Statement"
         },
         {
           href: "https://govuk-prototype-kit.herokuapp.com/",
-          text: "GOV.UK Prototype Kit " + releaseVersion
+          text: "GOV.UK Prototype Kit " + releaseVersion
         },
         {
           href: "/prototype-admin/clear-data",
-          text: "Clear data"
+          text: "Clear data"
         }
       ]
     }

--- a/app/views/privacy-notice.html
+++ b/app/views/privacy-notice.html
@@ -1,0 +1,204 @@
+{% extends "layout.html" %}
+{% block pageTitle %} DfE Maths and Physics Service
+Prototype {% endblock %}
+{% block beforeContent %}
+  {{ govukPhaseBanner({ tag: {
+text: "beta" }, html: 'This is a new service – your
+<a class="govuk-link" href="#">feedback</a> will help us to improve it.' }) }}
+
+  {{
+  govukBackLink({
+    text: "Back",
+    href: "/start"
+  })
+}}
+{% endblock %}
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-xl">
+        Privacy Notice: Claim a payment for teaching maths or physics
+      </h1>
+
+      <h2 class="govuk-heading-l">
+        Who we are
+      </h2>
+
+      <p class="govuk-body">
+        This work is being carried out by the Department for Education (DfE) Digital, which is a part of DfE. DfE engages
+        the private companies The Dextrous Web Ltd and Paper Design Studio Ltd to help improve and provide the service.
+        For the purpose of data protection legislation, DfE is the data controller for the personal data processed as
+        part of Claim a payment for teaching maths or physics. Claim a payment for teaching maths or physics is a free
+        and optional service for eligible teachers to claim back student loan repayments.
+      </p>
+
+      <h2 class="govuk-heading-l">
+        When we collect personal information
+      </h2>
+
+      <p class="govuk-body">
+        We receive your personal data when you submit it:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>to claim a payment</li>
+        <li>when contacting us for support using the service, to leave feedback or for any other matters</li>
+      </ul>
+
+      <h2 class="govuk-heading-l">
+        What personal information we will collect
+      </h2>
+
+      <p class="govuk-body">
+        We will collect your personal information such as your:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          your name, email and (if applicable) your phone number when you contact us
+        </li>
+        <li>
+          your email address if you include it with feedback to us on the service or agree to be contacted for user research
+          purposes
+        </li>
+        <li>
+          your Internet Protocol (IP) address
+        </li>
+      </ul>
+
+      <h2 class="govuk-heading-l">
+        How we will use your information
+      </h2>
+
+      <p class="govuk-body">
+        If you contact us, DfE and (where applicable) The Dextrous Web Ltd and Paper Design Studio Ltd will use your
+        name and contact information for the purpose of responding to you and providing support. We will not share this
+        information with any other parties.
+      </p>
+
+      <h2 class="govuk-heading-l">
+        Why our use of your personal data is lawful
+      </h2>
+
+      <p class="govuk-body">
+        In order for our use of your personal data to be lawful, we need to meet one or more conditions in the data
+        protection legislation.  For the purpose of ‘Claim a payment for teaching maths or physics‘, the Department processes your
+        data where it is necessary for the performance of a task carried out in the public interest or in the exercise of
+        official authority (Article 6(1)(e) of the General Data Protection Regulation).
+      </p>
+
+      <h2 class="govuk-heading-l">
+        Who we will make your personal data available to
+      </h2>
+
+      <p class="govuk-body">
+        We sometimes need to make personal data available to other organisations. These might include contracted partners
+        (who we have employed to process your personal data on our behalf) and/or other organisations (with whom we need
+        to share your personal data for specific purposes).
+      </p>
+
+      <p class="govuk-body">
+        Where we need to share your personal data with others, we ensure that this data sharing complies with data
+        protection legislation.
+      </p>
+
+      <p class="govuk-body">
+        The Department for Education use your data:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          to enable users to use the service and receive updates
+        </li>
+        <li>
+          for security purposes: collecting the IP addresses of people visiting ‘Claim a payment for teaching maths or physics’
+          (for example, if we were receiving continuous direct denial of service attacks from an IP address then we could block it)
+        </li>
+      </ul>
+
+      <h2 class="govuk-heading-l">
+        How we access your personal data
+      </h2>
+
+      <p class="govuk-body">
+        To process your claim we will compare the information you have provided with records kept on the Teachers
+        Pension Scheme and the Database of Qualified Teachers. This is so we can validate your claim.
+      </p>
+
+      <h2 class="govuk-heading-l">
+        How long we will keep your personal data
+      </h2>
+
+      <p class="govuk-body">
+        Neither DfE nor its delivery partners will keep your personal data longer than we need it for the purpose(s) of
+        research, security and/or delivery of the service. Your data will be deleted when DfE and its delivery partners no
+        longer need it for these purposes.
+      </p>
+
+      <h2 class="govuk-heading-l">
+        Your data protection rights
+      </h2>
+
+      <p class="govuk-body">
+        You have the right:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          to ask us for access to information about you that we hold
+        </li>
+        <li>
+          to have your personal data rectified, if it is inaccurate or incomplete
+        </li>
+        <li>
+          to ask us to delete your personal data unless there is a legal reason to continue to store and process it
+        </li>
+        <li>
+          to restrict our processing of your personal data (i.e. permitting its storage but no further processing)
+        </li>
+        <li>
+          to object to direct marketing (including profiling) and processing for the purposes of scientific/historical
+          research and statistics
+        </li>
+        <li>
+          not to be subject to decisions based purely on automated processing where it produces a legal or similarly
+          significant effect on you
+        </li>
+      </ul>
+
+      <p class="govuk-body">
+        If you need to contact us regarding any of the above, or have any other questions about how your personal
+        information will be used, please <a href="https://www.gov.uk/contact-dfe" class="govuk-link">contact the DfE</a>.
+      </p>
+
+      <p class="govuk-body">
+        The Information Commissioner’s Office makes further information about your data protection rights available in
+        their <a href="https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/" class="govuk-link">
+        Guide to the General Data Protection Regulation (GDPR)</a>.
+      </p>
+
+      <h2 class="govuk-heading-l">
+        The right to lodge a complaint
+      </h2>
+
+      <p class="govuk-body">
+        You have the right to raise any concerns with the <a href="https://ico.org.uk/concerns/" class="govuk-link">
+        Information Commissioner’s Office (ICO)</a>.
+      </p>
+
+      <h2 class="govuk-heading-l">
+        Last updated
+      </h2>
+
+      <p class="govuk-body">
+        We may need to update this privacy notice periodically so we recommend that you revisit this information from time
+        to time. This version was last updated on 19 August 2019.
+      </p>
+
+    </div>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Pretty much a straight copy of the teacher student loans page with the
name of the service swapped. All emails on the page are external so no
need to worry about them.