### PR TITLE
Update Readme for old dynos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Teacher’s Payment Service
+
 ## Maths and Physics Prototype
 
 ### Documentation
+
 Documentation can be found in the [docs](docs) directory.
 Design System - [Getting started guide](https://design-system.service.gov.uk/get-started/)
 
@@ -11,13 +13,21 @@ Design System - [Getting started guide](https://design-system.service.gov.uk/get
 
 ### Install dependencies
 
-```npm install```
+`npm install`
 
 ### Run the kit
 
-```npm start```
+`npm start`
 
 Go to localhost:3000 in your browser.
 
 ### Heroku Instance
+
 http://dfe-mps-prototype.herokuapp.com/
+
+### Older versions
+
+The older iterations of the maths and physics journeys have been kept on Heroku
+but the dynos turned off so we don't incur a cost.
+
+You can find them with in DfE > dfe-teachers-payment-service.


### PR DESCRIPTION
Older versions have had the dynos turned off so they are still there,
they just need turning on again if someone wants to see them.